### PR TITLE
Add mode support for elementwise parameters and improve BatchNorm import

### DIFF
--- a/brainscale/__init__.py
+++ b/brainscale/__init__.py
@@ -16,7 +16,7 @@
 # -*- coding: utf-8 -*-
 
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 
 from brainscale._etrace_algorithms import (

--- a/brainscale/__init__.py
+++ b/brainscale/__init__.py
@@ -16,6 +16,7 @@
 # -*- coding: utf-8 -*-
 
 
+__version_info__ = (0, 0, 10)
 __version__ = "0.0.10"
 
 

--- a/brainscale/nn/_normalizations.py
+++ b/brainscale/nn/_normalizations.py
@@ -22,7 +22,8 @@ import brainstate
 import brainunit as u
 import jax
 
-if brainstate.__version__ >= '0.1.3':
+version = tuple(map(int, brainstate.__version__.split('.')))
+if version >= (0, 1, 3):
     from brainstate.nn._normalizations import _BatchNorm
 else:
     from brainstate.nn._interaction._normalizations import _BatchNorm


### PR DESCRIPTION
## Summary by Sourcery

Add mode-based support for elementwise parameter operations in e-trace algorithms to enable correct shape validation and gradient aggregation under batching, and improve normalization import based on numeric brainstate version

Enhancements:
- Add mode argument to e-trace initialization and gradient solver functions
- Allow shape mismatches for ElemWiseParam under batching in IO state initialization
- Adjust gradient summation logic for elementwise parameters in batching mode
- Replace _sum_last_dim helper with configurable _sum_dim for arbitrary-axis reductions
- Use numeric version parsing to select BatchNorm import based on brainstate version