### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -1,17 +1,75 @@
 name: Publish to PyPI.org
+
 on:
   release:
     types: [published]
+  # Allow manual runs if needed
+  workflow_dispatch:
+
+# Grant minimal permissions; include id-token for OIDC if enabled on PyPI
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   pypi:
+    name: Build and Publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: python setup.py bdist_wheel
-      - name: Publish package
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install build backend
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "Release tag: $TAG"
+          PKG_VERSION=$(python - <<'PY'
+          import re, pathlib
+          init = pathlib.Path('brainscale/__init__.py').read_text(encoding='utf-8')
+          m = re.search(r"__version__\s*=\s*\"([^\"]+)\"", init)
+          print(m.group(1) if m else '')
+          PY
+          )
+          echo "Package version: ${PKG_VERSION}"
+          TAG_STRIPPED=${TAG#v}
+          if [[ -z "$PKG_VERSION" ]]; then
+            echo "Could not determine package version from brainscale/__init__.py" >&2
+            exit 1
+          fi
+          if [[ "$TAG_STRIPPED" != "$PKG_VERSION" ]]; then
+            echo "Tag ($TAG) does not match package version ($PKG_VERSION)" >&2
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: |
+          python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts
+          path: dist/*
+
+      - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          # For API token auth: keep using PYPI_API_TOKEN secret
           password: ${{ secrets.PYPI_API_TOKEN }}
+          # If using OIDC Trusted Publishers on PyPI, omit password above.
+          # You can also enable skip-existing to avoid failures on re-publish attempts
+          skip-existing: true

--- a/brainscale/__init__.py
+++ b/brainscale/__init__.py
@@ -16,7 +16,7 @@
 # -*- coding: utf-8 -*-
 
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 
 from brainscale._etrace_algorithms import (

--- a/brainscale/__init__.py
+++ b/brainscale/__init__.py
@@ -16,6 +16,7 @@
 # -*- coding: utf-8 -*-
 
 
+__version_info__ = (0, 0, 10)
 __version__ = "0.0.10"
 
 

--- a/brainscale/nn/_normalizations.py
+++ b/brainscale/nn/_normalizations.py
@@ -22,7 +22,8 @@ import brainstate
 import brainunit as u
 import jax
 
-if brainstate.__version__ >= '0.1.3':
+version = tuple(map(int, brainstate.__version__.split('.')))
+if version >= (0, 1, 3):
     from brainstate.nn._normalizations import _BatchNorm
 else:
     from brainstate.nn._interaction._normalizations import _BatchNorm


### PR DESCRIPTION
## Summary by Sourcery

Improve the Publish workflow and extend the etrace algorithm implementation with mode-awareness and enhanced shape handling.

Enhancements:
- Add a Mode parameter to multiple etrace functions and pass instance mode into algorithm calls
- Adjust hidden-state shape validation to allow element-wise parameters under batching mode and raise errors otherwise
- Generalize the sum utility by replacing `_sum_last_dim` with a configurable `_sum_dim` and update its usage in gradient computations
- Refactor tensor shape calculations in I/O trace initialization and gradient solvers for consistency

Build:
- Enable manual dispatch, set minimal permissions with OIDC support, and ensure release tags match package versions in the GitHub Actions workflow
- Use setup-python@v5 with Python 3.12, install build backend, build sdist/wheel, upload artifacts, and skip existing PyPI uploads

Chores:
- Update normalization import logic to use numeric version tuple comparison for brainstate